### PR TITLE
build(jenkins): update node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,14 @@ APP=blog
 VERSION?=latest
 BUILD?=$(shell /bin/date +%Y%m%d%H%M%S)
 # linux/amd64, linux/arm64
-PLATFORM?=linux/arm64
+PLATFORM?=linux/arm64,linux/amd64
 REGISTRY?=loneexile
+HARBOR_REGISTRY?=harbor.voidbox.io/loneexile
 
 ximage:
 	docker buildx create --name imagebuilder --driver=remote tcp://buildkitd:1234 --bootstrap --use;
 	cat ~/.docker/buildx/instances/imagebuilder;
-	docker buildx build --cache-from=type=local,src=/var/lib/buildkit --cache-to=type=local,dest=/var/lib/buildkit,mode=max -o type=registry --build-arg VERSION=$(VERSION) --build-arg BUILD=$(BUILD) --platform=$(PLATFORM) . -t $(REGISTRY)/$(APP):$(BUILD) -t $(REGISTRY)/$(APP):latest
+	docker buildx build --cache-from=type=local,src=/var/lib/buildkit --cache-to=type=local,dest=/var/lib/buildkit,mode=max \
+		-o type=registry --build-arg VERSION=$(VERSION) --build-arg BUILD=$(BUILD) \
+		--platform=$(PLATFORM) . -t $(REGISTRY)/$(APP):$(BUILD) -t $(REGISTRY)/$(APP):latest \
+		-t $(HARBOR_REGISTRY)/$(APP):$(BUILD) -t $(HARBOR_REGISTRY)/$(APP):latest

--- a/deploy/config/Jenkinsfile
+++ b/deploy/config/Jenkinsfile
@@ -70,6 +70,7 @@ pipeline {
             steps {
                 container('docker') {
                     sh 'ls'
+                    sh 'pwd'
                     sh 'echo $CONTAINER_REGISTRY_CREDENTIALS_PSW | docker login --username $CONTAINER_REGISTRY_CREDENTIALS_USR --password-stdin'
                     sh 'echo $CONTAINER_REGISTRY_CREDENTIALS_HARBOR_PSW | docker login https://harbor.voidbox.io --username $CONTAINER_REGISTRY_CREDENTIALS_HARBOR_USR --password-stdin'
                     // sh 'make ximage VERSION=v1.0.0'

--- a/deploy/config/Jenkinsfile
+++ b/deploy/config/Jenkinsfile
@@ -1,6 +1,7 @@
 pipeline {
     environment {
         CONTAINER_REGISTRY_CREDENTIALS = credentials('docker')
+        CONTAINER_REGISTRY_CREDENTIALS_HARBOR = credentials('harbor')
         SONARQUBE_SCANNER_HOME = tool 'sonar-scanner' // NOTE: need to match the name of the SonarQube installer in Tools
     }
 
@@ -10,6 +11,13 @@ pipeline {
             apiVersion: v1
             kind: Pod
             spec:
+              nodeSelector: 
+                chip: intel
+              tolerations:
+                - key: "chip"
+                  operator: "Equal"
+                  value: "intel"
+                  effect: "NoSchedule"
               containers:
               - name: docker
                 image: loneexile/docker-cli:latest
@@ -24,7 +32,7 @@ pipeline {
                   mountPath: /var/lib/buildkit
                   subPath: buildkit
               - name: jnlp
-                image: loneexile/jenkins-inbound-node:arm64
+                image: loneexile/jenkins-inbound-node:latest
                 command:
                  - /usr/local/bin/jenkins-agent
                 tty: true
@@ -63,6 +71,7 @@ pipeline {
                 container('docker') {
                     sh 'ls'
                     sh 'echo $CONTAINER_REGISTRY_CREDENTIALS_PSW | docker login --username $CONTAINER_REGISTRY_CREDENTIALS_USR --password-stdin'
+                    sh 'echo $CONTAINER_REGISTRY_CREDENTIALS_HARBOR_PSW | docker login https://harbor.voidbox.io --username $CONTAINER_REGISTRY_CREDENTIALS_HARBOR_USR --password-stdin'
                     // sh 'make ximage VERSION=v1.0.0'
                     sh 'make ximage'
                 }


### PR DESCRIPTION
This pull request includes several changes to the `Makefile` and `Jenkinsfile` to support multi-platform builds and integrate with a new Harbor registry. The most important changes include updating the platform targets, adding new registry credentials, and modifying the Jenkins pipeline configuration.

### Multi-platform build support and registry integration:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L5-R15): Updated the `PLATFORM` variable to include both `linux/arm64` and `linux/amd64`, and added `HARBOR_REGISTRY` for the new Harbor registry. Modified the `docker buildx build` command to push images to both the existing registry and the new Harbor registry.

### Jenkins pipeline configuration:

* [`deploy/config/Jenkinsfile`](diffhunk://#diff-b1d68820796d70a62fe4d38d646483b27f226bda3615d99fd9acbf08aacc5b00R4): Added `CONTAINER_REGISTRY_CREDENTIALS_HARBOR` to the environment for Harbor registry credentials.
* [`deploy/config/Jenkinsfile`](diffhunk://#diff-b1d68820796d70a62fe4d38d646483b27f226bda3615d99fd9acbf08aacc5b00R14-R20): Added `nodeSelector` and `tolerations` to ensure the Jenkins pod runs on nodes with Intel chips.
* [`deploy/config/Jenkinsfile`](diffhunk://#diff-b1d68820796d70a62fe4d38d646483b27f226bda3615d99fd9acbf08aacc5b00L27-R35): Updated the `jnlp` container image to use the latest tag instead of a specific architecture tag.
* [`deploy/config/Jenkinsfile`](diffhunk://#diff-b1d68820796d70a62fe4d38d646483b27f226bda3615d99fd9acbf08aacc5b00R74): Added a command to log in to the Harbor registry using the new credentials.